### PR TITLE
diagnose time prior update checks

### DIFF
--- a/docs/source/quickstart_unilateral.ipynb
+++ b/docs/source/quickstart_unilateral.ipynb
@@ -322,6 +322,8 @@
     "\n",
     "Here, it's important that the first argument is the support of the probability mass function, i.e., the discrete time-steps from 0 to `max_time`. Also, all parameters must have default values. Otherwise, there would be cases when such a stored distribution cannot be accessed.\n",
     "\n",
+    "Lastly, if some parameters have bounds, like e.g. the binomial distribution, they should raise a `ValueError`. This exception is propagated upwards but causes the `likelihood` method to simply return `-np.inf`. That way it will be seamlessly rejected during an MCMC sampling round.\n",
+    "\n",
     "Let's look at a concrete, binomial example:"
    ]
   },
@@ -336,6 +338,7 @@
     "def binom_pmf(k: np.ndarray, n: int, p: float):\n",
     "    \"\"\"Binomial PMF\"\"\"\n",
     "    if p > 1. or p < 0.:\n",
+    "        # This value error is important to enable seamless sampling!\n",
     "        raise ValueError(\"Binomial prob must be btw. 0 and 1\")\n",
     "    q = (1. - p)\n",
     "    binom_coeff = factorial(n) / (factorial(k) * factorial(n - k))\n",

--- a/lymph/diagnose_times.py
+++ b/lymph/diagnose_times.py
@@ -197,8 +197,10 @@ class Distribution:
                 self._frozen = self.normalize(
                     self._func(self.support, **new_kwargs)
                 )
-            except ValueError:
-                raise ValueError("Invalid params for distribution over diagnose times")
+            except ValueError as val_err:
+                raise ValueError(
+                    "Invalid parameter(s) provided to distribution over diagnose times"
+                ) from val_err
 
             self._kwargs = new_kwargs
         else:

--- a/lymph/diagnose_times.py
+++ b/lymph/diagnose_times.py
@@ -44,7 +44,9 @@ class Distribution:
         function must return a list of probabilities for each diagnose time.
 
         Note:
-            All arguments except ``support`` must have default values.
+            All arguments except ``support`` must have default values and if some
+            parameters have bounds (like the binomial distribution's ``p``), the
+            function must raise a ``ValueError`` if the parameter is invalid.
 
         Since ``max_time`` specifies the support of the distribution (rangin from 0 to
         ``max_time``), it must be provided if a parametrized function is passed. If a


### PR DESCRIPTION
Make sure a `ValueError` in the parametrized diagnose time `Distribution` is propagated to the `set_params()` method.